### PR TITLE
Bug fix for empty, but not null, handlers

### DIFF
--- a/octoprint_pantilt/__init__.py
+++ b/octoprint_pantilt/__init__.py
@@ -57,7 +57,7 @@ class PantiltPlugin(octoprint.plugin.SettingsPlugin,
 		self.tiltValue = max(self._settings.get(["tilt", "minValue"]), min(self._settings.get(["tilt", "maxValue"]), tiltValue))
 
 		# if there are anly pantilt handlers, loop through them, then return
-		if self.pantiltHandlers is not None:
+		if len(self.pantiltHandlers) > 0:
 			values = {'pan': self.panValue, 'panMin': self._settings.get(["pan", "minValue"]),
 					  'panMax': self._settings.get(["pan", "maxValue"]),
 					  'tilt': self.tiltValue, 'tiltMin': self._settings.get(["tilt", "minValue"]),


### PR DESCRIPTION
Hi Salandora,

I found a bug in my last pull request - self.panTiltHandlers was never None (but could be empty).  I ran across this trying to execute a custom shell script - but the code never got there since it always entered the handler loop, then returned.  This update fixes that problem.

The script (pigpio bash shell script) is uploaded here: https://github.com/c-devine/OctoPrint-PanTilt-Script